### PR TITLE
Checking existence of userData to discard loading of empty skill boxes

### DIFF
--- a/src/components/User.jsx
+++ b/src/components/User.jsx
@@ -61,7 +61,7 @@ const User = () => {
         <div>
           <h3>Skills</h3>
           <div className="skills">
-            {Object.keys(skills).length > 0
+            {Object.keys(skills).length > 0 || userData != null
               ? Object.keys(skills).map((s) => <span key={s}>{s}</span>)
               : [...Array(5)].map((a) => (
                   <span


### PR DESCRIPTION
Fixes issue #7 by checking if userData is `null`. This mimics the checking of whether data has loaded. If data is loaded, then empty boxes are removed, regardless of the fact that there might be no skills present.